### PR TITLE
Implement changes necessary for drift_crdt implementation.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,18 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: false
+          checked: false
+          constructor: ""
+          create_factory: true
+          create_field_map: false
+          create_per_field_to_json: false
+          create_to_json: true
+          disallow_unrecognized_keys: false
+          explicit_to_json: false
+          field_rename: none
+          generic_argument_factories: false
+          ignore_unannotated: false
+          include_if_null: true

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -1,0 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
+
+class BaseCrdtSerializable {
+  final int id;
+
+  final String hlc;
+
+  @JsonKey(name: 'node_id')
+  final String nodeId;
+
+  final String modified;
+
+  @JsonKey(name: 'is_deleted')
+  final int isDeleted;
+
+  BaseCrdtSerializable(this.id, this.hlc, this.nodeId, this.modified, this.isDeleted);
+}

--- a/lib/src/sqlite_api.dart
+++ b/lib/src/sqlite_api.dart
@@ -33,4 +33,33 @@ class SqliteApi extends DatabaseApi {
     assert(_db is Database, 'Cannot start a transaction within a transaction');
     return (_db as Database).transaction((t) => action(SqliteApi(t)));
   }
+
+  Batch batch() => _db.batch();
+
+  @override
+  Future<List<Map<String, Object?>>> rawQuery(String sql,
+      [List<Object?>? arguments]) {
+    return _db.rawQuery(sql, arguments);
+  }
+
+  @override
+  Future<int> rawUpdate(String sql, [List<Object?>? arguments]) {
+    return _db.rawUpdate(sql, arguments);
+  }
+
+  @override
+  Future<int> rawInsert(String sql, [List<Object?>? arguments]) {
+    return _db.rawInsert(sql, arguments);
+  }
+
+  @override
+  Future<int> rawDelete(String sql, [List<Object?>? arguments]) {
+    return _db.rawDelete(sql, arguments);
+  }
+
+  @override
+  Future<void> close() {
+    return (_db as Database).close();
+  }
 }
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,9 @@ dependencies:
   sqflite_common_ffi: ^2.3.0+2
   sqflite_common_ffi_web: ^0.4.0
   sql_crdt: ^2.1.3
-#    path: ../sql_crdt
+  json_annotation: ^4.8.1
 
 dev_dependencies:
   lints: any
   test: any
+  json_serializable: ^6.2.0


### PR DESCRIPTION
These changes are a result of my work on an implementation of sqlite CRDT implementation for Drift (see: https://github.com/JanezStupar/drift/tree/sqlite_crdt/drift_crdt).

My work relies on the work of @cachapa (`sql_crdt` and `sqlite_crdt`) libraries and Simon Binder's `drift_sqflite` library.

The changes are mostly related to expansion of the support for the sqflite API within `sqlite_crdt` of the scope that was necessary to get the `drift_crdt` working.

Only new features are the migration within `sqlite_crdt.dart` and a serialization stub based on `json_serializable`.

I felt like those were appropriate places to dump the new features.

Let me know if you are open to accepting this contribution and what changes you feel need to be made to make them acceptable.