### PR TITLE
Major performance refactor with a few breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.0
+
+Major performance refactor with a few breaking changes
+
+- Change how tables and primary keys are fetched to minimize reads
+- Allow for more efficient bulk writing using Sqlite batches
+- Rework abstractions to expose the Sqlite batch API
+- Rename classes to better reflect their goals
+- Correctly identify and forbid semicolon separated statements
+
 ## 2.1.7
 
 - Add support for inserts from select queries

--- a/lib/src/batch_executor.dart
+++ b/lib/src/batch_executor.dart
@@ -1,0 +1,17 @@
+import 'package:sqflite_common/sqlite_api.dart';
+import 'package:sql_crdt/sql_crdt.dart';
+import 'package:sqlite_crdt/src/sqlite_api.dart';
+
+/// Wrapper around Sqlite batches that automatically applies CRDT metadata to
+/// inserted records.
+///
+/// Note that timestamps are fixed at the moment of instantiation, so creating
+/// long-lived batches is discouraged.
+class BatchExecutor extends CrdtExecutor {
+  final Batch _batch;
+
+  BatchExecutor(this._batch, Hlc hlc) : super(BatchApi(_batch), hlc);
+
+  /// Commit this batch atomically. See Sqlite documentation for details.
+  Future<List<Object?>> commit() => _batch.commit();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_crdt
 description: Dart implementation of Conflict-free Replicated Data Types (CRDTs) using Sqlite
-version: 2.1.7
+version: 3.0.0
 homepage: https://github.com/cachapa/sqlite_crdt
 repository: https://github.com/cachapa/sqlite_crdt
 issue_tracker: https://github.com/cachapa/sqlite_crdt/issues
@@ -12,7 +12,7 @@ dependencies:
   sqflite_common: ^2.5.3
   sqflite_common_ffi: ^2.3.2+1
   sqflite_common_ffi_web: ^0.4.2+3
-  sql_crdt: ^2.1.7
+  sql_crdt: ^3.0.0
 #    path: ../sql_crdt
 
 dev_dependencies:

--- a/test/sql_crdt_test.dart
+++ b/test/sql_crdt_test.dart
@@ -1,0 +1,384 @@
+import 'dart:async';
+
+import 'package:sql_crdt/sql_crdt.dart';
+import 'package:test/test.dart';
+
+void main() {}
+
+void runSqlCrdtTests(SqlCrdt crdt) {
+  group('Basic', () {
+    setUp(() async {
+      await crdt.execute('''
+        CREATE TABLE users (
+          id INTEGER NOT NULL,
+          name TEXT,
+          PRIMARY KEY (id)
+        )
+      ''');
+    });
+
+    tearDown(() => dropAllTables(crdt));
+
+    test('Node ID', () {
+      expect(crdt.nodeId.isEmpty, false);
+    });
+
+    test('Canonical time', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final result = await crdt.query('SELECT * FROM users');
+      final hlc = (result.first['hlc'] as String).toHlc;
+      expect(crdt.canonicalTime, hlc);
+
+      await insertUser(crdt, 2, 'Jane Doe');
+      final newResult = await crdt.query('SELECT * FROM users');
+      final newHlc = (newResult.last['hlc'] as String).toHlc;
+      expect(newHlc > hlc, isTrue);
+      expect(crdt.canonicalTime, newHlc);
+    });
+
+    test('Create table', () async {
+      await crdt.execute('''
+        CREATE TABLE test (
+          id INTEGER NOT NULL,
+          name TEXT,
+          PRIMARY KEY (id)
+        )
+      ''');
+      expect(await crdt.query('SELECT * FROM test'), []);
+      expect((await crdt.getTables()).toList(), ['users', 'test']);
+    });
+
+    test('Insert', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'John Doe');
+    });
+
+    test('Insert without arguments', () async {
+      await crdt.execute('''
+        INSERT INTO users (id, name)
+        VALUES (1, 'John Doe')
+      ''');
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'John Doe');
+    });
+
+    test('Update', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final insertHlc =
+          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
+      await updateUser(crdt, 1, 'Jane Doe');
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'Jane Doe');
+      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
+    });
+
+    test('Update without arguments', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final insertHlc =
+          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
+      await crdt.execute('''
+        UPDATE users SET name = 'Jane Doe'
+        WHERE id = 1
+      ''');
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'Jane Doe');
+      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
+    });
+
+    test('Upsert', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final insertHlc =
+          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
+      await crdt.execute('''
+        INSERT INTO users (id, name) VALUES (?1, ?2)
+        ON CONFLICT (id) DO UPDATE SET name = ?2
+      ''', [1, 'Jane Doe']);
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'Jane Doe');
+      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
+    });
+
+    test('Upsert without arguments', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final insertHlc =
+          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
+      await crdt.execute('''
+        INSERT INTO users (id, name) VALUES (1, 'Jane Doe')
+        ON CONFLICT (id) DO UPDATE SET name = 'Jane Doe'
+      ''');
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'Jane Doe');
+      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
+    });
+
+    test('Delete', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      await crdt.execute('''
+        DELETE FROM users
+        WHERE id = ?1
+      ''', [1]);
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'John Doe');
+      expect(result.first['is_deleted'], 1);
+    });
+
+    test('Delete without arguments', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      await crdt.execute('''
+        DELETE FROM users
+        WHERE id = 1
+      ''');
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'John Doe');
+      expect(result.first['is_deleted'], 1);
+    });
+
+    test('Transaction', () async {
+      await crdt.transaction((txn) async {
+        await insertUser(txn, 1, 'John Doe');
+        await insertUser(txn, 2, 'Jane Doe');
+      });
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.length, 2);
+      expect(result.first['hlc'], result.last['hlc']);
+    });
+
+    test('Changeset', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final result = await crdt.getChangeset();
+      expect(result['users']!.first['name'], 'John Doe');
+    });
+
+    test('Simple merge', () async {
+      final hlc = Hlc.now('test_node_id');
+      await crdt.merge({
+        'users': [
+          {
+            'id': 1,
+            'name': 'John Doe',
+            'hlc': hlc,
+          },
+        ],
+      });
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.first['name'], 'John Doe');
+      expect(result.first['hlc'] as String, hlc.toString());
+    });
+
+    test('Merge large changeset', () async {
+      final length = 10000;
+      final hlc = Hlc.now('test_node_id');
+      final changeset = {
+        'users': List.generate(
+          length,
+          (i) => {
+            'id': i,
+            'name': 'John Doe $i',
+            'hlc': hlc,
+          },
+        ),
+      };
+      await crdt.merge(changeset);
+
+      final result = await crdt.query('SELECT * FROM users');
+      expect(result.length, length);
+      expect(result.first['name'], 'John Doe 0');
+      expect(result.first['hlc'] as String, hlc.toString());
+      expect(result.last['name'], 'John Doe ${length - 1}');
+      expect(result.first['hlc'] as String, hlc.toString());
+    });
+  });
+
+  group('Write from query', () {
+    setUp(() async {
+      await crdt.execute('''
+        CREATE TABLE users (
+          id INTEGER NOT NULL,
+          name TEXT,
+          PRIMARY KEY (id)
+        )
+      ''');
+      await crdt.execute('''
+        CREATE TABLE other_users (
+          id INTEGER NOT NULL,
+          name TEXT,
+          PRIMARY KEY (id)
+        )
+      ''');
+      await insertUser(crdt, 1, 'John Doe');
+    });
+
+    tearDown(() => dropAllTables(crdt));
+
+    test('Insert from select', () async {
+      await crdt.execute('''
+        INSERT INTO other_users (id, name)
+        SELECT id, name FROM users
+      ''');
+      final result1 = await crdt.query('SELECT * FROM users');
+      final result2 = await crdt.query('SELECT * FROM other_users');
+      expect(result2.first['name'], 'John Doe');
+      expect(result2.first['hlc'], isNot(result1.first['hlc']));
+    });
+  });
+
+  group('Watch', () {
+    setUp(() async {
+      await crdt.execute('''
+        CREATE TABLE users (
+          id INTEGER NOT NULL,
+          name TEXT,
+          PRIMARY KEY (id)
+        )
+      ''');
+      await crdt.execute('''
+        CREATE TABLE purchases (
+          id INTEGER NOT NULL,
+          user_id INTEGER NOT NULL,
+          price INTEGER NOT NULL,
+          PRIMARY KEY (id)
+        )
+      ''');
+    });
+
+    tearDown(() => dropAllTables(crdt));
+
+    test('Emit on watch', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users'),
+        emits((List<Map<String, Object?>> e) => e.first['name'] == 'John Doe'),
+      );
+      await streamTest;
+    });
+
+    test('Emit on insert', () async {
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users'),
+        emitsInOrder([
+          [],
+          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
+        ]),
+      );
+      await insertUser(crdt, 1, 'John Doe');
+      await streamTest;
+    });
+
+    test('Emit on update', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users'),
+        emitsInOrder([
+          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
+          (List<Map<String, Object?>> e) => e.first['name'] == 'Jane Doe',
+        ]),
+      );
+      await updateUser(crdt, 1, 'Jane Doe');
+      await streamTest;
+    });
+
+    test('Emit on delete', () async {
+      await insertUser(crdt, 1, 'John Doe');
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users WHERE is_deleted = 0'),
+        emitsInOrder([
+          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
+          [],
+        ]),
+      );
+      await deleteUser(crdt, 1);
+      await streamTest;
+    });
+
+    test('Emit on transaction', () async {
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users'),
+        emitsInOrder([
+          [],
+          (List<Map<String, Object?>> e) =>
+              e.first['name'] == 'John Doe' && e.last['name'] == 'Jane Doe',
+        ]),
+      );
+      await crdt.transaction((txn) async {
+        await insertUser(txn, 1, 'John Doe');
+        await insertUser(txn, 2, 'Jane Doe');
+      });
+      await streamTest;
+    });
+
+    test('Emit on merge', () async {
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users'),
+        emitsInOrder([
+          [],
+          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
+        ]),
+      );
+      await crdt.merge({
+        'users': [
+          {
+            'id': 1,
+            'name': 'John Doe',
+            'hlc': Hlc.now('test_node_id'),
+          },
+        ],
+      });
+      await streamTest;
+    });
+
+    test('Emit only on selected table', () async {
+      final streamTest = expectLater(
+        crdt.watch('SELECT * FROM users'),
+        emitsInOrder([
+          [],
+          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
+        ]),
+      );
+      await insertPurchase(crdt, 1, 1, 12);
+      await insertUser(crdt, 1, 'John Doe');
+      await streamTest;
+    });
+
+    test('Emit on all selected tables', () async {
+      final streamTest = expectLater(
+        crdt.watch(
+            'SELECT users.name, price FROM users LEFT JOIN purchases ON users.id = user_id'),
+        emitsInOrder([
+          [],
+          (List<Map<String, Object?>> e) =>
+              e.first['name'] == 'John Doe' && e.first['price'] == null,
+          (List<Map<String, Object?>> e) =>
+              e.first['name'] == 'John Doe' && e.first['price'] == 12,
+        ]),
+      );
+      await insertUser(crdt, 1, 'John Doe');
+      await insertPurchase(crdt, 1, 1, 12);
+      await streamTest;
+    });
+  });
+}
+
+FutureOr<void> insertUser(dynamic crdt, int id, String name) => crdt.execute('''
+      INSERT INTO users (id, name)
+      VALUES (?1, ?2)
+    ''', [id, name]);
+
+Future<void> updateUser(SqlCrdt crdt, int id, String name) => crdt.execute('''
+      UPDATE users SET name = ?2
+      WHERE id = ?1
+    ''', [id, name]);
+
+Future<void> deleteUser(SqlCrdt crdt, int id) =>
+    crdt.execute('DELETE FROM users WHERE id = ?1', [id]);
+
+Future<void> insertPurchase(SqlCrdt crdt, int id, int userId, int price) =>
+    crdt.execute('''
+      INSERT INTO purchases (id, user_id, price)
+      VALUES (?1, ?2, ?3)
+    ''', [id, userId, price]);
+
+Future<void> dropAllTables(SqlCrdt crdt) async =>
+    Future.wait((await crdt.getTables())
+        .map((table) => 'DROP TABLE $table')
+        .map((sql) => crdt.execute(sql)));

--- a/test/sqlite_crdt_test.dart
+++ b/test/sqlite_crdt_test.dart
@@ -1,74 +1,32 @@
+import 'dart:async';
+
 import 'package:sqlite_crdt/sqlite_crdt.dart';
 import 'package:test/test.dart';
 
-void main() {
-  group('Basic', () {
-    late SqlCrdt crdt;
+import 'sql_crdt_test.dart';
 
+Future<void> main() async {
+  final crdt = await SqliteCrdt.openInMemory();
+
+  runSqlCrdtTests(crdt);
+
+  group('Sqlite features', () {
     setUp(() async {
-      crdt = await SqliteCrdt.openInMemory(
-        version: 1,
-        onCreate: (db, version) async {
-          await db.execute('''
-            CREATE TABLE users (
-              id INTEGER NOT NULL,
-              name TEXT,
-              PRIMARY KEY (id)
-            )
-          ''');
-        },
-      );
-    });
-
-    test('Node ID', () {
-      expect(crdt.nodeId.isEmpty, false);
-    });
-
-    test('Canonical time', () async {
-      expect(crdt.canonicalTime.dateTime,
-          DateTime.fromMillisecondsSinceEpoch(0).toUtc());
-
-      await _insertUser(crdt, 1, 'John Doe');
-      final result = await crdt.query('SELECT * FROM users');
-      final hlc = (result.first['hlc'] as String).toHlc;
-      expect(crdt.canonicalTime, hlc);
-
-      await _insertUser(crdt, 2, 'Jane Doe');
-      final newResult = await crdt.query('SELECT * FROM users');
-      final newHlc = (newResult.last['hlc'] as String).toHlc;
-      expect(newHlc > hlc, isTrue);
-      expect(crdt.canonicalTime, newHlc);
-    });
-
-    test('Create table', () async {
       await crdt.execute('''
-        CREATE TABLE test (
+        CREATE TABLE users (
           id INTEGER NOT NULL,
           name TEXT,
           PRIMARY KEY (id)
         )
       ''');
-      final result = await crdt.query('SELECT * FROM test');
-      expect(result, []);
     });
 
-    test('Insert', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'John Doe');
-    });
-
-    test('Insert without arguments', () async {
-      await crdt.execute('''
-        INSERT INTO users (id, name)
-        VALUES (1, 'John Doe')
-      ''');
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'John Doe');
+    tearDown(() async {
+      await crdt.execute('DROP TABLE users');
     });
 
     test('Replace', () async {
-      await _insertUser(crdt, 1, 'John Doe');
+      await insertUser(crdt, 1, 'John Doe');
       final insertHlc =
           (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
       await crdt.execute(
@@ -79,7 +37,7 @@ void main() {
     });
 
     test('Replace without arguments', () async {
-      await _insertUser(crdt, 1, 'John Doe');
+      await insertUser(crdt, 1, 'John Doe');
       final insertHlc =
           (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
       await crdt
@@ -89,307 +47,26 @@ void main() {
       expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
     });
 
-    test('Update', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final insertHlc =
-          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
-      await _updateUser(crdt, 1, 'Jane Doe');
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'Jane Doe');
-      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
-    });
+    test('Batch insert', () async {
+      final batch = crdt.batch();
+      insertUser(batch, 1, 'John Doe 1');
+      insertUser(batch, 2, 'John Doe 2');
+      await batch.commit();
 
-    test('Update without arguments', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final insertHlc =
-          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
-      await crdt.execute('''
-        UPDATE users SET name = 'Jane Doe'
-        WHERE id = 1
-      ''');
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'Jane Doe');
-      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
-    });
-
-    test('Upsert', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final insertHlc =
-          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
-      await crdt.execute('''
-        INSERT INTO users (id, name) VALUES (?1, ?2)
-        ON CONFLICT (id) DO UPDATE SET name = ?2
-      ''', [1, 'Jane Doe']);
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'Jane Doe');
-      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
-    });
-
-    test('Upsert without arguments', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final insertHlc =
-          (await crdt.query('SELECT hlc FROM users')).first['hlc'] as String;
-      await crdt.execute('''
-        INSERT INTO users (id, name) VALUES (1, 'Jane Doe')
-        ON CONFLICT (id) DO UPDATE SET name = 'Jane Doe'
-      ''');
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'Jane Doe');
-      expect((result.first['hlc'] as String).compareTo(insertHlc), 1);
-    });
-
-    test('Delete', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      await crdt.execute('''
-        DELETE FROM users
-        WHERE id = ?1
-      ''', [1]);
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'John Doe');
-      expect(result.first['is_deleted'], 1);
-    });
-
-    test('Delete without arguments', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      await crdt.execute('''
-        DELETE FROM users
-        WHERE id = 1
-      ''');
-      final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'John Doe');
-      expect(result.first['is_deleted'], 1);
-    });
-
-    test('Transaction', () async {
-      await crdt.transaction((txn) async {
-        await _insertUser(txn, 1, 'John Doe');
-        await _insertUser(txn, 2, 'Jane Doe');
-      });
       final result = await crdt.query('SELECT * FROM users');
       expect(result.length, 2);
+      expect(result.first['name'], 'John Doe 1');
+      expect(result.last['name'], 'John Doe 2');
       expect(result.first['hlc'], result.last['hlc']);
     });
 
-    test('Changeset', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final result = await crdt.getChangeset();
-      expect(result['users']!.first['name'], 'John Doe');
-    });
+    test('Uncommitted batch', () async {
+      final batch = crdt.batch();
+      insertUser(batch, 1, 'John Doe 1');
+      insertUser(batch, 2, 'John Doe 2');
 
-    test('Merge', () async {
-      final hlc = Hlc.now('test_node_id');
-      await crdt.merge({
-        'users': [
-          {
-            'id': 1,
-            'name': 'John Doe',
-            'hlc': hlc,
-          },
-        ],
-      });
       final result = await crdt.query('SELECT * FROM users');
-      expect(result.first['name'], 'John Doe');
-      expect(result.first['hlc'] as String, hlc.toString());
-    });
-  });
-
-  group('Write from query', () {
-    late SqlCrdt crdt;
-
-    setUp(() async {
-      crdt = await SqliteCrdt.openInMemory(
-        version: 1,
-        onCreate: (db, version) async {
-          await db.execute('''
-            CREATE TABLE users (
-              id INTEGER NOT NULL,
-              name TEXT,
-              PRIMARY KEY (id)
-            )
-          ''');
-          await db.execute('''
-            CREATE TABLE other_users (
-              id INTEGER NOT NULL,
-              name TEXT,
-              PRIMARY KEY (id)
-            )
-          ''');
-        },
-      );
-      await _insertUser(crdt, 1, 'John Doe');
-    });
-
-    test('Insert from select', () async {
-      await crdt.execute('''
-        INSERT INTO other_users (id, name)
-        SELECT id, name FROM users
-      ''');
-      final result1 = await crdt.query('SELECT * FROM users');
-      final result2 = await crdt.query('SELECT * FROM other_users');
-      expect(result2.first['name'], 'John Doe');
-      expect(result2.first['hlc'], isNot(result1.first['hlc']));
-    });
-  });
-
-  group('Watch', () {
-    late SqlCrdt crdt;
-
-    setUp(() async {
-      crdt = await SqliteCrdt.openInMemory(
-        version: 1,
-        onCreate: (db, version) async {
-          await db.execute('''
-            CREATE TABLE users (
-              id INTEGER NOT NULL,
-              name TEXT,
-              PRIMARY KEY (id)
-            )
-          ''');
-          await db.execute('''
-            CREATE TABLE purchases (
-              id INTEGER NOT NULL,
-              user_id INTEGER NOT NULL,
-              price REAL NOT NULL,
-              PRIMARY KEY (id)
-            )
-          ''');
-        },
-      );
-    });
-
-    test('Emit on watch', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users'),
-        emits((List<Map<String, Object?>> e) => e.first['name'] == 'John Doe'),
-      );
-      await streamTest;
-    });
-
-    test('Emit on insert', () async {
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users'),
-        emitsInOrder([
-          [],
-          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
-        ]),
-      );
-      await _insertUser(crdt, 1, 'John Doe');
-      await streamTest;
-    });
-
-    test('Emit on update', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users'),
-        emitsInOrder([
-          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
-          (List<Map<String, Object?>> e) => e.first['name'] == 'Jane Doe',
-        ]),
-      );
-      await _updateUser(crdt, 1, 'Jane Doe');
-      await streamTest;
-    });
-
-    test('Emit on delete', () async {
-      await _insertUser(crdt, 1, 'John Doe');
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users WHERE is_deleted = 0'),
-        emitsInOrder([
-          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
-          [],
-        ]),
-      );
-      await _deleteUser(crdt, 1);
-      await streamTest;
-    });
-
-    test('Emit on transaction', () async {
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users'),
-        emitsInOrder([
-          [],
-          (List<Map<String, Object?>> e) =>
-              e.first['name'] == 'John Doe' && e.last['name'] == 'Jane Doe',
-        ]),
-      );
-      await crdt.transaction((txn) async {
-        await _insertUser(txn, 1, 'John Doe');
-        await _insertUser(txn, 2, 'Jane Doe');
-      });
-      await streamTest;
-    });
-
-    test('Emit on merge', () async {
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users'),
-        emitsInOrder([
-          [],
-          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
-        ]),
-      );
-      await crdt.merge({
-        'users': [
-          {
-            'id': 1,
-            'name': 'John Doe',
-            'hlc': Hlc.now('test_node_id'),
-          },
-        ],
-      });
-      await streamTest;
-    });
-
-    test('Emit only on selected table', () async {
-      final streamTest = expectLater(
-        crdt.watch('SELECT * FROM users'),
-        emitsInOrder([
-          [],
-          (List<Map<String, Object?>> e) => e.first['name'] == 'John Doe',
-        ]),
-      );
-      await _insertPurchase(crdt, 1, 1, 12.3);
-      await _insertUser(crdt, 1, 'John Doe');
-      await streamTest;
-    });
-
-    test('Emit on all selected tables', () async {
-      final streamTest = expectLater(
-        crdt.watch(
-            'SELECT users.name, price FROM users LEFT JOIN purchases ON users.id = user_id'),
-        emitsInOrder([
-          [],
-          (List<Map<String, Object?>> e) =>
-              e.first['name'] == 'John Doe' && e.first['price'] == null,
-          (List<Map<String, Object?>> e) =>
-              e.first['name'] == 'John Doe' && e.first['price'] == 12.3,
-        ]),
-      );
-      await _insertUser(crdt, 1, 'John Doe');
-      await _insertPurchase(crdt, 1, 1, 12.3);
-      await streamTest;
+      expect(result.length, 0);
     });
   });
 }
-
-Future<void> _insertUser(TimestampedCrdt crdt, int id, String name) =>
-    crdt.execute('''
-      INSERT INTO users (id, name)
-      VALUES (?1, ?2)
-    ''', [id, name]);
-
-Future<void> _updateUser(TimestampedCrdt crdt, int id, String name) =>
-    crdt.execute('''
-      UPDATE users SET name = ?2
-      WHERE id = ?1
-    ''', [id, name]);
-
-Future<void> _deleteUser(TimestampedCrdt crdt, int id) =>
-    crdt.execute('DELETE FROM users WHERE id = ?1', [id]);
-
-Future<void> _insertPurchase(
-        TimestampedCrdt crdt, int id, int userId, double price) =>
-    crdt.execute('''
-      INSERT INTO purchases (id, user_id, price)
-      VALUES (?1, ?2, ?3)
-    ''', [id, userId, price]);


### PR DESCRIPTION
- Change how tables and primary keys are fetched to minimize reads.
- Allow for more efficient bulk writing using Sqlite batches.
- Rework abstractions to expose the Sqlite batch API.
- Rename classes to better reflect their goals.
- Correctly identify and forbid semicolon separated statements.